### PR TITLE
fix_code_style.sh: add a check argument

### DIFF
--- a/tools/fix_code_style.sh
+++ b/tools/fix_code_style.sh
@@ -1,13 +1,47 @@
 #!/bin/bash
-TOOLSDIR=$( dirname "${BASH_SOURCE[0]}" )
-if [ "$1" = "-p" ]; then
-PRUNE_DIRS=$2
-fi
+for i in "$@"
+do
+
+case $i in
+	--check)
+	DRYRUN=true
+	shift
+	;;
+	-p)
+	PRUNE_DIRS="${i#*=}"
+	shift
+	;;
+	*)
+	;;
+esac
+shift
+done
+
 for d in ${PRUNE_DIRS}; do
 PRUNE_CMD="${PRUNE_CMD} -path '$d' -prune -o "
 done
-echo "find . ${PRUNE_CMD} -name '*.c' -o -name '*.cpp' -o -name '*.hpp' -o -name '*.h' -print"
+
+TOOLSDIR=$( dirname "${BASH_SOURCE[0]}" )
+
+RESULT=0
+
 for f in $(find . ${PRUNE_CMD} -path "*.git/*" -prune -o -name '*.c' -print -o -name '*.cpp' -print -o -name '*.hpp' -print -o -name '*.h' -print); do
-	echo $f
-	astyle --options=${TOOLSDIR}/astylerc --preserve-date --quiet $f
+	if [ "$DRYRUN" = true ] ; then
+		astyle --options=${TOOLSDIR}/astylerc --preserve-date --dry-run $f | grep "Formatted"
+		if [[ $? -eq 0 ]]
+		then
+			echo $f "bad formatting"
+		RESULT=1
+	fi
+
+	else
+		astyle --options=${TOOLSDIR}/astylerc --preserve-date $f | grep "Formatted"
+	fi
 done
+
+if [[ $RESULT -eq 1 ]]
+then
+	echo 'Please run "make fix-style"'
+fi
+
+exit $RESULT


### PR DESCRIPTION
This allows to run the script without doing any changes so that bad
formatting can be detected on travis.
