### PR TITLE
fix_code_style.sh: fix cmd line arg parsing

### DIFF
--- a/tools/fix_code_style.sh
+++ b/tools/fix_code_style.sh
@@ -8,7 +8,8 @@ case $i in
 	shift
 	;;
 	-p)
-	PRUNE_DIRS="${i#*=}"
+	shift
+	PRUNE_DIRS="${1}"
 	shift
 	;;
 	*)
@@ -18,7 +19,7 @@ shift
 done
 
 for d in ${PRUNE_DIRS}; do
-PRUNE_CMD="${PRUNE_CMD} -path '$d' -prune -o "
+	PRUNE_CMD="${PRUNE_CMD} -path '$d' -prune -o "
 done
 
 TOOLSDIR=$( dirname "${BASH_SOURCE[0]}" )


### PR DESCRIPTION
Before the directory were not ignored as they should have been. 
