### PR TITLE
Adds new API's defined for DSPAL v1.1.

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,0 +1,12 @@
+# DSPAL
+
+Version Number: 1.1
+
+Date: 08/04/2016
+
+- Addition of support for running individual tests from the dspal_tester command line.  Adds an additional test for testing the frequency of FARF debug output.
+
+- Addition of PWM support to the DSPAL API, including unit test coverage in dspal_tester if the correct version of the aDSP firmware is detected.
+
+
+

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 The DSP Abstraction Layer (DSPAL) provides a standard interface for porting
 code to the Hexagon processor.
 
+## Change Log
+
+The DSPAL change log is located [here](CHANGE_LOG.md).
+
 ## Setup Development Environment
 
 See [GettingStarted](https://github.com/ATLFlight/ATLFlightDocs/blob/master/GettingStarted.md)
@@ -19,8 +23,9 @@ export PATH=${HEXAGON_SDK_ROOT}/gcc-linaro-arm-linux-gnueabihf-4.8-2013.08_linux
 
 ```
 git clone https://github.com/ATLFlight/dspal
+cd dspal
 git submodule update --init --recursive
-cd dspal/test
+cd test
 make
 ```
 

--- a/include/dev_fs_lib_pwm.h
+++ b/include/dev_fs_lib_pwm.h
@@ -1,0 +1,138 @@
+/****************************************************************************
+ * Copyright (c) 2016 James Y. Wilson. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <stdint.h>
+
+/**
+ * @file
+ * The functions in this module define the interface for configuring one
+ * or more PWM signals.  Once the PWM signal is configured it will be generated
+ * at the specified period and width, until it is changed by another function
+ * call.
+ *
+ * The width of PWM signals specified by the caller can be changed for
+ * individual I/O lines, but all I/O lines must have the same period.
+ * Additional instances of this device can be opened to define a different group
+ * of PWM signals at a different period.
+ *
+ * @par
+ * Sample source code to generate a time varying PWM signal is included below.
+ * @include pwm_test_imp.c
+ */
+
+/**
+ * @brief
+ * The maximum number of pwm signals allowed in a signal definition.
+ */
+#define DEV_FS_PWM_MAX_NUM_SIGNALS 8
+
+/**
+ * @brief
+ * The PWM device path uses the following format:
+ * /dev/pwm-{gpio pin number}
+ * Pin numbers start at 1 and may go to up to the max number of GPIO pins supported
+ * by the SoC.
+ */
+#define DEV_FS_PWM_DEVICE_TYPE_STRING  "/dev/pwm-"
+
+/**
+ * @brief
+ * Error codes describing an error condition of the PWM signal generator.  POSIX
+ * error codes may also be returned.
+ */
+#define DEV_FS_PWM_ERROR_SIGNALS_ALREADY_DEFINED -4095
+
+/**
+ * @brief
+ * ioctl codes used to extend the functionality of the standard read/write file
+ * semantics for PWM signal generation
+ */
+enum DSPAL_PWM_IOCTLS {
+	PWM_IOCTL_INVALID = -1, /**< invalid IOCTL code, used to return an error */                                 //!< PWM_IOCTL_INVALID
+	PWM_IOCTL_SIGNAL_DEFINITION, /**< used to define the gpio number(s) and period of the pulse width(s) */     //!< PWM_IOCTL_SIGNAL_DEFINITION
+	PWM_IOCTL_GET_UPDATE_BUFFER, /**< returns a buffer used to update the pulse width in real-time */      //!< PWM_IOCTL_GET_PULSE_WIDTH_BUFFER
+	PWM_IOCTL_MAX_NUM, /**< number of valid IOCTL codes defined for the PWM generator */                        //!< PWM_IOCTL_MAX_NUM
+};
+
+/**
+ * @brief
+ * Structure used to define the GPIO ID of the I/O line and the width of the pulse
+ * used by the signal generator.  This structure is also used to return a buffer containing
+ * an array of structures that can be accessed directly to effect a change in the width
+ * of the pulse.  @see PWM_IOCTL_GET_UPDATE_BUFFER
+ *
+ */
+struct dspal_pwm {
+	uint32_t gpio_id;               /**< ID of the GPIO line used for PWM generation */
+	uint32_t gpio_cfg;              /**< internal use only */
+	uint32_t pulse_width_in_usecs;  /**< duration of the pulse in usecs */
+	uint32_t pulse_state;           /**< a read-only value, indicating the current state of the pulse */
+};
+
+/**
+ * @brief
+ * Structure used in the ioctl: PWM_IOCTL_SIGNAL_DEFINITION
+ *
+ * Upon the return from the function signal generation will begin at the specified period and pulse width
+ * for each I/O line specified.
+ */
+struct dspal_pwm_ioctl_signal_definition {
+	uint32_t period_in_usecs; /**< the period of the pulses generated, can only be changed once after the device is first opened */
+	uint32_t num_gpios; /**< number of signals specified in the following array */
+	struct dspal_pwm *pwm_signal; /**< array defining the GPIO lines and pulse widths to be used by the signal generator */
+};
+
+/**
+ * @brief
+ * Structure used in the ioctl: PWM_IOCTL_GET_UPDATE_BUFFER
+ *
+ * Returns a buffer that can be used to effect an immediate change in the width of the pulse.
+ * @par
+ * To change the width of a particular pulse the new pulse width should be written to the
+ * pulse_width_in_usecs structure member.  If the deadline for changing the state of the pulse
+ * has already passed, or the width of the pulse is less than the previous pulse width the
+ * new value will not take effect until the next period.
+ *
+ * No other structure member other than pulse_width_in_usecs may be modified.  To use different
+ * GPIO lines or change the period a new signal definition must be created.
+ *
+ * The I/O lines used cannot be changed from those defined in in the PWM_IOCTL_SIGNAL_DEFINITION structure.
+ */
+struct dspal_pwm_ioctl_update_buffer {
+	uint32_t num_gpios; /**< the number of PWM's specified in the following array */
+	struct dspal_pwm *pwm_signal; /**< array defining the GPIO lines and pulse widths to be used by the signal generator, can only be specified once after the device is first opened */
+	uint32_t reserved_1; /**< reserved value used for debugging. */
+	uint32_t reserved_2; /**< reserved value used for debugging. */
+};
+

--- a/test/Makefile
+++ b/test/Makefile
@@ -37,7 +37,7 @@ all: dspal_tester version_test
 ENV_VARS:
 	@[ ! -z "${HEXAGON_SDK_ROOT}" ] || (echo "HEXAGON_SDK_ROOT not set" && false)
 	@[ ! -z "${HEXAGON_TOOLS_ROOT}" ] || (echo "HEXAGON_TOOLS_ROOT not set" && false)
-	@[ `which arm-linux-gnueabihf-gcc` ] || (echo "Add ${HEXAGON_SDK_ROOT}/gcc-linaro-arm-linux-gnueabihf-4.8-2013.08_linux/bin to PATH" && false)
+	@[ `which arm-linux-gnueabihf-gcc` ] || (echo "Add ${HEXAGON_SDK_ROOT}/gcc-linaro-4.9-2014.11-x86_64_arm-linux-gnueabihf_linux/bin to PATH" && false)
 
 cmake_hexagon/bundle.cmake:
 	cd ../ && git submodule init

--- a/test/dspal_tester/CMakeLists.txt
+++ b/test/dspal_tester/CMakeLists.txt
@@ -35,8 +35,10 @@ include_directories(
 
 QURT_BUNDLE(APP_NAME dspal_tester
 	DSP_SOURCES
+		adsp_proc/farf_test.c
 		adsp_proc/gpio_test_imp.c
 		adsp_proc/i2c_test_imp.c
+		adsp_proc/pwm_test_imp.c
 		adsp_proc/posix_file_tests.c
 		adsp_proc/posix_pthread_tests.c
 		adsp_proc/posix_semaphore_tests.c
@@ -53,6 +55,8 @@ QURT_BUNDLE(APP_NAME dspal_tester
 		apps_proc/io_test_suite.h
 		apps_proc/posix_test_suite.c
 		apps_proc/posix_test_suite.h
+                apps_proc/test_mask_utils.c
+                apps_proc/test_mask_utils.h
 		common/test_utils.c
 	APPS_INCS
 		-Iinclude

--- a/test/dspal_tester/adsp_proc/farf_test.c
+++ b/test/dspal_tester/adsp_proc/farf_test.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- *   Copyright (c) 2015 James Wilson. All rights reserved.
+ *   Copyright (c) 2016 James Wilson. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,63 +30,57 @@
  *
  ****************************************************************************/
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-
-#include "adspmsgd.h"
-#include "rpcmem.h"
-
+#include <dspal_version.h>
+#include <unistd.h>
 #include "test_utils.h"
 #include "dspal_tester.h"
-#include "posix_test_suite.h"
-#include "io_test_suite.h"
-#include "test_mask_utils.h"
 
-/**
- * @brief Runs all the tests, the io tests and the posix tests.
- *
- * @param   argc[in]    number of arguments
- * @param   argv[in]    array of parameters (each is a char array)
- *
- * @return
- * TEST_PASS ------ All tests passed
- * TEST_FAIL ------ A test has failed
-*/
-
-int main(int argc, char *argv[])
+int dspal_tester_test_farf_log_info()
 {
-	int status = TEST_PASS;
+	const int NUM_MESSAGE_PERIODS = 5;
+	const int NUM_MESSAGES_PER_PERIOD = 20;
+	int message_periods[NUM_MESSAGE_PERIODS] = { 1e5, 1e4, 1e3, 1e2, 1e1 };
 
-	LOG_INFO("");
-
-	char test_mask[255];
-	if (test_mask_utils_process_cli_args(argc, argv, test_mask) != 0)
-	{
-		return 0;
-	}
-
-	LOG_INFO("Starting DSPAL tests");
-
-	dspal_tester_test_dspal_get_version_info();
-	status = run_posix_test_suite(test_mask);
-	status |= run_io_test_suite(test_mask + NUM_DSPAL_POSIX_TESTS);
-
-	if ((status & TEST_FAIL) == TEST_FAIL) {
-		LOG_INFO("DSPAL test failed.");
-
-	} else {
-		if ((status & TEST_SKIP) == TEST_SKIP) {
-			LOG_INFO("DSPAL some tests skipped.");
+	for (int i = 0; i < NUM_MESSAGE_PERIODS; i++) {
+		for (int j = 0; j < NUM_MESSAGES_PER_PERIOD; j++) {
+			LOG_INFO("[%d] LOG_INFO test at %d us period", j,
+					message_periods[i]);
+			usleep(message_periods[i]);
 		}
-
-		LOG_INFO("DSPAL tests succeeded.");
 	}
 
-	LOG_INFO("");
-	return status;
+	return 0;
 }
 
+int dspal_tester_test_farf_log_err()
+{
+	const int NUM_MESSAGE_PERIODS = 5;
+	const int NUM_MESSAGES_PER_PERIOD = 20;
+	int message_periods[NUM_MESSAGE_PERIODS] = { 1e5, 1e4, 1e3, 1e2, 1e1 };
+
+	for (int i = 0; i < NUM_MESSAGE_PERIODS; i++) {
+		for (int j = 0; j < NUM_MESSAGES_PER_PERIOD; j++) {
+			LOG_ERR("[%d] LOG_ERR test at %d us period", j, message_periods[i]);
+			usleep(message_periods[i]);
+		}
+	}
+
+	return 0;
+}
+
+int dspal_tester_test_farf_log_debug()
+{
+	const int NUM_MESSAGE_PERIODS = 5;
+	const int NUM_MESSAGES_PER_PERIOD = 20;
+	int message_periods[NUM_MESSAGE_PERIODS] = { 1e5, 1e4, 1e3, 1e2, 1e1 };
+
+	for (int i = 0; i < NUM_MESSAGE_PERIODS; i++) {
+		for (int j = 0; j < NUM_MESSAGES_PER_PERIOD; j++) {
+			LOG_DEBUG("[%d] LOG_DEBUG test at %d us period", j,
+					message_periods[i]);
+			usleep(message_periods[i]);
+		}
+	}
+
+	return 0;
+}

--- a/test/dspal_tester/adsp_proc/pwm_test_imp.c
+++ b/test/dspal_tester/adsp_proc/pwm_test_imp.c
@@ -1,0 +1,156 @@
+/****************************************************************************
+ *   Copyright (c) 2016 James Wilson. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name ATLFlight nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <dev_fs_lib_pwm.h>
+#include <dspal_version.h>
+
+#include "test_status.h"
+#include "test_utils.h"
+
+/**
+* @brief
+* Test to define PWM signals at a specified period and vary the pulse width.
+*
+* @par
+* Test:
+* 1) Open the PWM device (/dev/pwm-1)
+* 2) Configure the
+*     GPIO 5 (pin 3, J9 on the Eagle Board)
+*
+* 3) Close the PWM device
+*
+* @return
+* SUCCESS ------ Test Passes
+* ERROR ------ Test Failed
+*/
+
+#define PWM_TEST_PULSE_WIDTH_INCREMENTS 10
+#define PWM_TEST_MINIMUM_PULSE_WIDTH 1050
+#define INCREMENT_PULSE_WIDTH(x,y) ((x + PWM_TEST_PULSE_WIDTH_INCREMENTS) >= y ? PWM_TEST_MINIMUM_PULSE_WIDTH : x + PWM_TEST_PULSE_WIDTH_INCREMENTS)
+
+int dspal_tester_pwm_test(void)
+{
+	int ret = SUCCESS;
+	int pulse_width;
+	int test_count;
+	struct dspal_version_info version;
+	int major_version, minor_version;
+
+	dspal_get_version_info_ext(&version);
+	strtok(version.version_string, "-.");
+	major_version = atoi(strtok(NULL, "-."));
+	minor_version = atoi(strtok(NULL, "-."));
+
+	if (major_version < 1 || (major_version == 1 && minor_version < 1))
+	{
+		LOG_INFO("unable to test PWM signaling, current version: %d.%d, requires version 1.1 or above",
+				major_version, minor_version);
+		return ERROR;
+	}
+	LOG_INFO("testing PWM signaling, DSPAL version: %d.%d", major_version, minor_version);
+
+	/*
+	 * Open PWM device
+	 */
+	int fd = -1;
+	fd = open("/dev/pwm-1", 0);
+
+	if (fd > 0) {
+		/*
+		 * Configure PWM device
+		 */
+		struct dspal_pwm pwm_gpio[4];
+		struct dspal_pwm_ioctl_signal_definition signal_definition;
+		struct dspal_pwm_ioctl_update_buffer *update_buffer;
+		struct dspal_pwm *pwm;
+
+		// Define the initial pulse width and number of the GPIO to
+		// use for this signal definition.
+		// 45,46,47,48
+		pwm_gpio[0].gpio_id = 45;
+		pwm_gpio[0].pulse_width_in_usecs = PWM_TEST_MINIMUM_PULSE_WIDTH;
+		pwm_gpio[1].gpio_id = 46;
+		pwm_gpio[1].pulse_width_in_usecs = PWM_TEST_MINIMUM_PULSE_WIDTH + 10;
+		pwm_gpio[2].gpio_id = 47;
+		pwm_gpio[2].pulse_width_in_usecs = PWM_TEST_MINIMUM_PULSE_WIDTH + 20;
+		pwm_gpio[3].gpio_id = 48;
+		pwm_gpio[3].pulse_width_in_usecs = PWM_TEST_MINIMUM_PULSE_WIDTH + 21;
+
+		// Describe the overall signal and reference the above array.
+		signal_definition.num_gpios = 4;
+		signal_definition.period_in_usecs = 2000;
+		signal_definition.pwm_signal = &pwm_gpio[0];
+
+		// Send the signal definition to the DSP.
+		if (ioctl(fd, PWM_IOCTL_SIGNAL_DEFINITION, &signal_definition) != 0) {
+			ret = ERROR;
+		}
+
+		// Retrieve the shared buffer which will be used below to update the desired
+		// pulse width.
+		if (ioctl(fd, PWM_IOCTL_GET_UPDATE_BUFFER, &update_buffer) != 0)
+		{
+			ret = ERROR;
+		}
+		pwm = &update_buffer->pwm_signal[0];
+		update_buffer->reserved_1 = 0;
+
+		// Wait for the ESC's to ARM:
+		usleep(1000000 * 5); // wait 5 seconds
+
+		// Change the speed of the motor, every 500 msecs.
+		for (test_count = 0; test_count < 30; test_count++)
+		{
+			pwm[0].pulse_width_in_usecs = INCREMENT_PULSE_WIDTH(pwm[0].pulse_width_in_usecs, signal_definition.period_in_usecs);
+			pwm[1].pulse_width_in_usecs = INCREMENT_PULSE_WIDTH(pwm[1].pulse_width_in_usecs, signal_definition.period_in_usecs);;
+			pwm[2].pulse_width_in_usecs = INCREMENT_PULSE_WIDTH(pwm[2].pulse_width_in_usecs, signal_definition.period_in_usecs);
+			pwm[3].pulse_width_in_usecs = INCREMENT_PULSE_WIDTH(pwm[3].pulse_width_in_usecs, signal_definition.period_in_usecs);
+			usleep(1000 * 500);
+			LOG_INFO("reserved_1 count: %d", update_buffer->reserved_1);
+		}
+
+		/*
+		 * Close the device ID
+		 */
+		close(fd);
+	} else {
+		ret = ERROR;
+	}
+
+	return ret;
+}

--- a/test/dspal_tester/apps_proc/io_test_suite.c
+++ b/test/dspal_tester/apps_proc/io_test_suite.c
@@ -33,34 +33,43 @@
 #include <stdio.h>
 #include "dspal_tester.h"
 #include "test_utils.h"
+#include "test_mask_utils.h"
 
-int run_io_test_suite(void)
+#define VERSION_PREFIX "DSPAL-"
+
+int run_io_test_suite(char test_mask[])
 {
 	int test_results = TEST_PASS;
 
 	LOG_INFO("testing device path access");
-	test_results |= display_test_results(dspal_tester_spi_test(), "spi loopback test");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_spi_test, "spi loopback test");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_serial_test, "serial I/O test");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_i2c_test, "i2c test");
 
-	test_results |= display_test_results(dspal_tester_serial_test(), "serial I/O test");
+	LOG_INFO("testing PWM signaling");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_pwm_test, "pwm_test");
 
-	test_results |= display_test_results(dspal_tester_i2c_test(), "i2c test");
+    LOG_INFO("testing FARF");
+    test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_farf_log_info, "farf log_info test");
+    test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_farf_log_err, "farf log_err test");
+    test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_farf_log_debug, "farf log_debug test");
 
 	LOG_INFO("testing GPIO");
-	test_results |= display_test_results(dspal_tester_test_gpio_open_close(), "gpio open/close test");
-	test_results |= display_test_results(dspal_tester_test_gpio_ioctl_io(), "gpio ioctl I/O mode test");
-	test_results |= display_test_results(dspal_tester_test_gpio_read_write(), "gpio read/write test");
-	test_results |= display_test_results(dspal_tester_test_gpio_int(), "gpio INT test");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_gpio_open_close, "gpio open/close test");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_gpio_ioctl_io, "gpio ioctl I/O mode test");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_gpio_read_write, "gpio read/write test");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_gpio_int, "gpio INT test");
 
 	LOG_INFO("testing file I/O");
-	test_results |= display_test_results(dspal_tester_test_posix_file_open_close(), "file open/close");
-	test_results |= display_test_results(dspal_tester_test_posix_file_read_write(), "file read/write");
-	test_results |= display_test_results(dspal_tester_test_posix_file_open_trunc(), "file open_trunc");
-	test_results |= display_test_results(dspal_tester_test_posix_file_open_append(), "file open_append");
-	test_results |= display_test_results(dspal_tester_test_posix_file_ioctl(), "file ioctl");
-	test_results |= display_test_results(dspal_tester_test_posix_file_fsync(), "file fsync");
-	test_results |= display_test_results(dspal_tester_test_posix_file_remove(), "file remove");
-	test_results |= display_test_results(dspal_tester_test_fopen_fclose(), "fopen/fclose test");
-	test_results |= display_test_results(dspal_tester_test_fwrite_fread(), "fwrite/fread test");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_posix_file_open_close, "file open/close");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_posix_file_read_write, "file read/write");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_posix_file_open_trunc, "file open_trunc");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_posix_file_open_append, "file open_append");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_posix_file_ioctl, "file ioctl");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_posix_file_fsync, "file fsync");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_posix_file_remove, "file remove");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_fopen_fclose, "fopen/fclose test");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_fwrite_fread, "fwrite/fread test");
 
 	return test_results;
 }

--- a/test/dspal_tester/apps_proc/io_test_suite.h
+++ b/test/dspal_tester/apps_proc/io_test_suite.h
@@ -39,23 +39,31 @@
  *
  * @par
  * Tests that are run (in order)
- * 1) dspal_tester_spi_test
- * 2) dspal_tester_serial_test
- * 3) dspal_tester_i2c_test
- * 4) dspal_tester_test_gpio_open_close
- * 5) dspal_tester_test_gpio_ioctl_io
- * 6) dspal_tester_test_gpio_read_write
- * 7) dspal_tester_test_gpio_int
- * 8) dspal_tester_test_posix_file_open
- * 9) dspal_tester_test_posix_file_close
- * 10) dspal_tester_test_posix_file_read
- * 11) dspal_tester_test_posix_file_write
- * 12) dspal_tester_test_posix_file_ioctl
+ *  1) spi loopback test (dspal_tester_spi_test)
+ *  2) serial I/O test (dspal_tester_serial_test)
+ *  3) i2c test (dspal_tester_i2c_test)
+ *  4) pwm_test (dspal_tester_pwm_test)
+ *  5) farf log_info test (dspal_tester_test_farf_log_info)
+ *  6) farf log_err test (dspal_tester_test_farf_log_err)
+ *  7) farf log_debug test (dspal_tester_test_farf_log_debug)
+ *  8) gpio open/close test (dspal_tester_test_gpio_open_close)
+ *  9) gpio ioctl I/O mode test (dspal_tester_test_gpio_ioctl_io)
+ * 10) gpio read/write test (dspal_tester_test_gpio_read_write)
+ * 11) gpio INT test (dspal_tester_test_gpio_int)
+ * 12) file open/close (dspal_tester_test_posix_file_open_close)
+ * 13) file read/write (dspal_tester_test_posix_file_read_write)
+ * 14) file open_trunc (dspal_tester_test_posix_file_open_trunc)
+ * 15) file open_append (dspal_tester_test_posix_file_open_append)
+ * 16) file ioctl (dspal_tester_test_posix_file_ioctl)
+ * 17) file fsync (dspal_tester_test_posix_file_fsync)
+ * 18) file remove (dspal_tester_test_posix_file_remove)
+ * 19) fopen/fclose test (dspal_tester_test_fopen_fclose)
+ * 20) fwrite/fread test (dspal_tester_test_fwrite_fread)
  *
  * @return
  * TEST_PASS ------ All tests passed
  * TEST_FAIL ------ One or more tests failed
 */
-int run_io_test_suite(void);
+int run_io_test_suite(char test_mask[]);
 
 #endif /* IO_TEST_SUITE_H_ */

--- a/test/dspal_tester/apps_proc/posix_test_suite.c
+++ b/test/dspal_tester/apps_proc/posix_test_suite.c
@@ -34,54 +34,55 @@
 
 #include "test_utils.h"
 #include "dspal_tester.h"
+#include "test_mask_utils.h"
 
-int run_posix_test_suite(void)
+int run_posix_test_suite(char test_mask[])
 {
 	int test_results = TEST_PASS;
 
 	LOG_INFO("testing time.h");
 
-	test_results |= display_test_results(dspal_tester_test_clockid(), "clockid values exist");
-	test_results |= display_test_results(dspal_tester_test_sigevent(), "sigevent values exist");
-	test_results |= display_test_results(dspal_tester_test_time(), "time returns good value");
-	test_results |= display_test_results(dspal_tester_test_timer_realtime_sig_none(), "timer realtime");
-	test_results |= display_test_results(dspal_tester_test_timer_monotonic_sig_none(), "timer monotonic");
-	test_results |= display_test_results(dspal_tester_test_timer_process_cputime_sig_none(), "timer process cputime");
-	test_results |= display_test_results(dspal_tester_test_timer_thread_cputime_sig_none(), "timer thread cputime");
-	test_results |= display_test_results(dspal_tester_test_time_return_value(), "time return value");
-	test_results |= display_test_results(dspal_tester_test_time_param(), "time parameter");
-	test_results |= display_test_results(dspal_tester_test_usleep(), "usleep for two seconds");
-	test_results |= display_test_results(dspal_tester_test_clock_getres(), "clock_getres");
-	test_results |= display_test_results(dspal_tester_test_clock_gettime(), "clock_gettime");
-	test_results |= display_test_results(dspal_tester_test_clock_settime(), "clock_settime");
-	test_results |= display_test_results(dspal_tester_test_one_shot_timer_cb(), "one shot timer cb");
-	test_results |= display_test_results(dspal_tester_test_periodic_timer_cb(), "periodic timer cb");
-	test_results |= display_test_results(dspal_tester_test_periodic_timer_signal_cb(), "periodic timer signal cb");
-	test_results |= display_test_results(dspal_tester_test_periodic_timer_sigwait(), "periodic timer sigwait");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_clockid, "clockid values exist");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_sigevent, "sigevent values exist");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_time, "time returns good value");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_timer_realtime_sig_none, "timer realtime");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_timer_monotonic_sig_none, "timer monotonic");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_timer_process_cputime_sig_none, "timer process cputime");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_timer_thread_cputime_sig_none, "timer thread cputime");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_time_return_value, "time return value");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_time_param, "time parameter");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_usleep, "usleep for two seconds");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_clock_getres, "clock_getres");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_clock_gettime, "clock_gettime");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_clock_settime, "clock_settime");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_one_shot_timer_cb, "one shot timer cb");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_periodic_timer_cb, "periodic timer cb");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_periodic_timer_signal_cb, "periodic timer signal cb");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_periodic_timer_sigwait, "periodic timer sigwait");
 
 	LOG_INFO("testing pthread.h");
 
-	test_results |= display_test_results(dspal_tester_test_pthread_attr_init(), "pthread attr init");
-	test_results |= display_test_results(dspal_tester_test_pthread_create(), "pthread create");
-	test_results |= display_test_results(dspal_tester_test_pthread_cancel(), "pthread cancel");
-	test_results |= display_test_results(dspal_tester_test_pthread_self(), "pthread self");
-	test_results |= display_test_results(dspal_tester_test_pthread_exit(), "pthread exit");
-	test_results |= display_test_results(dspal_tester_test_pthread_kill(), "pthread kill");
-	test_results |= display_test_results(dspal_tester_test_pthread_cond_timedwait(), "pthread condition timed wait");
-	test_results |= display_test_results(dspal_tester_test_pthread_mutex_lock(), "pthread mutex lock");
-	test_results |= display_test_results(dspal_tester_test_pthread_mutex_lock_thread(), "thread mutex lock thread");
-	test_results |= display_test_results(dspal_tester_test_pthread_stack(), "thread large allocation on stack");
-	test_results |= display_test_results(dspal_tester_test_pthread_heap(), "thread large allocation on heap");
-	test_results |= display_test_results(dspal_tester_test_usleep(), "usleep for two seconds");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_pthread_attr_init, "pthread attr init");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_pthread_create, "pthread create");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_pthread_cancel, "pthread cancel");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_pthread_self, "pthread self");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_pthread_exit, "pthread exit");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_pthread_kill, "pthread kill");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_pthread_cond_timedwait, "pthread condition timed wait");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_pthread_mutex_lock, "pthread mutex lock");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_pthread_mutex_lock_thread, "thread mutex lock thread");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_pthread_stack, "thread large allocation on stack");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_pthread_heap, "thread large allocation on heap");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_usleep, "usleep for two seconds");
 
 	LOG_INFO("testing semaphore.h");
 
-	test_results |= display_test_results(dspal_tester_test_semaphore_wait(), "semaphore wait");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_semaphore_wait, "semaphore wait");
 
 	LOG_INFO("testing C++");
 
-	test_results |= display_test_results(dspal_tester_test_cxx_heap(), "test C++ heap");
-	test_results |= display_test_results(dspal_tester_test_cxx_static(), "test C++ static initialization");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_cxx_heap, "test C++ heap");
+	test_results |= test_mask_utils_run_dspal_test(&test_mask, dspal_tester_test_cxx_static, "test C++ static initialization");
 
 	LOG_INFO("tests complete");
 

--- a/test/dspal_tester/apps_proc/posix_test_suite.h
+++ b/test/dspal_tester/apps_proc/posix_test_suite.h
@@ -40,40 +40,43 @@
  *
  * @par
  * Tests that are run (in order)
- * 1) dspal_tester_test_clockid
- * 2) dspal_tester_test_sigevent
- * 3) dspal_tester_test_time
- * 4) dspal_tester_test_timer_realtime_sig_none
- * 5) dspal_tester_test_timer_monotonic_sig_none
- * 6) dspal_tester_test_timer_process_cputime_sig_none
- * 7) dspal_tester_test_timer_thread_cputime_sig_none
- * 8) dspal_tester_test_time_return_value
- * 9) dspal_tester_test_time_param
- * 10) dspal_tester_test_usleep
- * 11) dspal_tester_test_clock_getres
- * 12) dspal_tester_test_clock_gettime
- * 13) dspal_tester_test_clock_settime
- * 14) dspal_tester_test_one_shot_timer_cb
- * 15) dspal_tester_test_periodic_timer_cb
- * 16) dspal_tester_test_periodic_timer_signal_cb
- * 17) dspal_tester_test_periodic_timer_sigwait
- * 18) dspal_tester_test_pthread_attr_init
- * 19) dspal_tester_test_pthread_create
- * 20) dspal_tester_test_pthread_cancel
- * 21) dspal_tester_test_pthread_self
- * 22) dspal_tester_test_pthread_exit
- * 23) dspal_tester_test_pthread_kill
- * 24) dspal_tester_test_pthread_mutex_lock
- * 25) dspal_tester_test_pthread_mutex_lock_thread
- * 26) dspal_tester_test_pthread_stack
- * 27) dspal_tester_test_pthread_heap
- * 28) dspal_tester_test_usleep
- * 29) dspal_tester_test_semaphore_wait
+ *  1)clockid values exist (dspal_tester_test_clockid)
+ *  2)sigevent values exist (dspal_tester_test_sigevent)
+ *  3)time returns good value (dspal_tester_test_time)
+ *  4)timer realtime (dspal_tester_test_timer_realtime_sig_none)
+ *  5)timer monotonic (dspal_tester_test_timer_monotonic_sig_none)
+ *  6)timer process cputime (dspal_tester_test_timer_process_cputime_sig_none)
+ *  7)timer thread cputime (dspal_tester_test_timer_thread_cputime_sig_none)
+ *  8)time return value (dspal_tester_test_time_return_value)
+ *  9)time parameter (dspal_tester_test_time_param)
+ * 10)usleep for two seconds (dspal_tester_test_usleep)
+ * 11)clock_getres (dspal_tester_test_clock_getres)
+ * 12)clock_gettime (dspal_tester_test_clock_gettime)
+ * 13)clock_settime (dspal_tester_test_clock_settime)
+ * 14)one shot timer cb (dspal_tester_test_one_shot_timer_cb)
+ * 15)periodic timer cb (dspal_tester_test_periodic_timer_cb)
+ * 16)periodic timer signal cb (dspal_tester_test_periodic_timer_signal_cb)
+ * 17)periodic timer sigwait (dspal_tester_test_periodic_timer_sigwait)
+ * 18)pthread attr init (dspal_tester_test_pthread_attr_init)
+ * 19)pthread create (dspal_tester_test_pthread_create)
+ * 20)pthread cancel (dspal_tester_test_pthread_cancel)
+ * 21)pthread self (dspal_tester_test_pthread_self)
+ * 22)pthread exit (dspal_tester_test_pthread_exit)
+ * 23)pthread kill (dspal_tester_test_pthread_kill)
+ * 24)pthread condition timed wait (dspal_tester_test_pthread_cond_timedwait)
+ * 25)pthread mutex lock (dspal_tester_test_pthread_mutex_lock)
+ * 26)thread mutex lock thread (dspal_tester_test_pthread_mutex_lock_thread)
+ * 27)thread large allocation on stack (dspal_tester_test_pthread_stack)
+ * 28)thread large allocation on heap (dspal_tester_test_pthread_heap)
+ * 29)usleep for two seconds (dspal_tester_test_usleep)
+ * 30)semaphore wait (dspal_tester_test_semaphore_wait)
+ * 31)test C++ heap (dspal_tester_test_cxx_heap)
+ * 32)test C++ static initialization (dspal_tester_test_cxx_static)
  *
  * @return
  * TEST_PASS ------ All tests passed
  * TEST_FAIL ------ One or more tests failed
 */
-int run_posix_test_suite();
+int run_posix_test_suite(char test_mask[]);
 
 #endif // POSIX_TEST_SUITE_H

--- a/test/dspal_tester/apps_proc/test_mask_utils.c
+++ b/test/dspal_tester/apps_proc/test_mask_utils.c
@@ -1,0 +1,147 @@
+/****************************************************************************
+ *   Copyright (c) 2016 James Wilson. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name ATLFlight nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include "test_utils.h"
+#include "test_mask_utils.h"
+
+void test_mask_utils_print_help()
+{
+  printf("dspal_tester [-h|--help] [test_mask]\n\n");
+  printf("test_mask: string containing 0 in position of disabled tests, 1 in position of enabled tests\n\n");
+  printf("List of tests:\n");
+  printf(" 1) test_clockid\n");
+  printf(" 2) test_sigevent\n");
+  printf(" 3) test_time\n");
+  printf(" 4) test_timer_realtime_sig_none\n");
+  printf(" 5) test_timer_monotonic_sig_none\n");
+  printf(" 6) test_timer_process_cputime_sig_none\n");
+  printf(" 7) test_timer_thread_cputime_sig_none\n");
+  printf(" 8) test_time_return_value\n");
+  printf(" 9) test_time_param\n");
+  printf("10) test_usleep\n");
+  printf("11) test_clock_getres\n");
+  printf("12) test_clock_gettime\n");
+  printf("13) test_clock_settime\n");
+  printf("14) test_one_shot_timer_cb\n");
+  printf("15) test_periodic_timer_cb\n");
+  printf("16) test_periodic_timer_signal_cb\n");
+  printf("17) test_periodic_timer_sigwait\n");
+  printf("18) test_pthread_attr_init\n");
+  printf("19) test_pthread_create\n");
+  printf("20) test_pthread_cancel\n");
+  printf("21) test_pthread_self\n");
+  printf("22) test_pthread_exit\n");
+  printf("23) test_pthread_kill\n");
+  printf("24) test_pthread_cond_timed_wait\n");
+  printf("25) test_pthread_mutex_lock\n");
+  printf("26) test_pthread_mutex_lock_thread\n");
+  printf("27) test_pthread_stack\n");
+  printf("28) test_pthread_heap\n");
+  printf("29) test_usleep\n");
+  printf("30) test_semaphore_wait\n");
+  printf("31) test_cxx_heap\n");
+  printf("32) test_cxx_static\n");
+  printf("33) spi_test\n");
+  printf("34) serial_test\n");
+  printf("35) i2c_test\n");
+  printf("36) pwm_test\n");
+  printf("37) test_farf_log_info\n");
+  printf("38) test_farf_log_err\n");
+  printf("39) test_farf_log_debug\n");
+  printf("40) test_gpio_open_close\n");
+  printf("41) test_gpio_ioctl_io\n");
+  printf("42) test_gpio_read_write\n");
+  printf("43) test_gpio_int\n");
+  printf("44) test_posix_file_open_close\n");
+  printf("45) test_posix_file_read_write\n");
+  printf("46) test_posix_file_open_trunc\n");
+  printf("47) test_posix_file_open_append\n");
+  printf("48) test_posix_file_ioctl\n");
+  printf("49) test_posix_file_fsync\n");
+  printf("50) test_posix_file_remove\n");
+  printf("51) test_fopen_fclose\n");
+  printf("52) test_fwrite_fread\n");
+}
+
+int test_mask_utils_process_cli_args(int argc, char* argv[], char test_mask[])
+{
+  if (argc < 2)
+  {
+    int i;
+    for (i = 0; i < TOTAL_NUM_DSPAL_TESTS; i++)
+    {
+      test_mask[i] = '1';
+    }
+    test_mask[i] = '\0';
+  }
+  else if (strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--help") == 0)
+  {
+    test_mask_utils_print_help();
+    return -1;
+  }
+  else
+  {
+    int i;
+    for (i = 0; argv[1][i] != '\0'; i++);
+    if (i != TOTAL_NUM_DSPAL_TESTS)
+    {
+      fprintf(stderr, "Argument error: Test mask is not %d characters long\n\n", TOTAL_NUM_DSPAL_TESTS);
+      test_mask_utils_print_help();
+      return -1;
+    }
+    else
+    {
+      memcpy(test_mask, argv[1], i + 1);
+    }
+  }
+  return 0;
+}
+
+int test_mask_utils_run_dspal_test(char** test_mask, int (*test_to_run)(void), char test_name[])
+{
+  int test_result = TEST_PASS;
+  if (*(*test_mask) == '1')
+  {
+    test_result = display_test_results((*test_to_run)(), test_name);
+  }
+
+  (*test_mask)++;
+
+  return test_result;
+}

--- a/test/dspal_tester/apps_proc/test_mask_utils.h
+++ b/test/dspal_tester/apps_proc/test_mask_utils.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- *   Copyright (c) 2015 James Wilson. All rights reserved.
+ *   Copyright (c) 2016 James Wilson. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,63 +30,36 @@
  *
  ****************************************************************************/
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#ifndef TEST_MASK_UTILS_H_
+#define TEST_MASK_UTILS_H_
 
-#include "adspmsgd.h"
-#include "rpcmem.h"
-
-#include "test_utils.h"
-#include "dspal_tester.h"
-#include "posix_test_suite.h"
-#include "io_test_suite.h"
-#include "test_mask_utils.h"
+#define NUM_DSPAL_POSIX_TESTS (32)
+#define NUM_DSPAL_IO_TESTS (20)
+#define TOTAL_NUM_DSPAL_TESTS (NUM_DSPAL_POSIX_TESTS + NUM_DSPAL_IO_TESTS)
 
 /**
- * @brief Runs all the tests, the io tests and the posix tests.
+ * @brief Prints help information.
+ */
+void test_mask_utils_print_help();
+
+/**
+ * @brief Processes command line arguments.
  *
- * @param   argc[in]    number of arguments
- * @param   argv[in]    array of parameters (each is a char array)
+ * @param   argc[in]         number of arguments
+ * @param   argv[in]         array of parameters (each is a char array)
+ * @param   test_mask[out]   output test mask from cli arguments
+ * @return 0, Do not exit immediately.
+ */
+int test_mask_utils_process_cli_args(int argc, char* argv[], char test_mask[]);
+
+/**
+ * @brief Runs the provided test if its enabled in the test mask
  *
- * @return
- * TEST_PASS ------ All tests passed
- * TEST_FAIL ------ A test has failed
-*/
+ * @param test_mask Mask of which tests are to be run
+ * @param test_to_run Pointer to the test function to be run
+ * @param test_name Human-readable test name
+ * @return Return value of the test function if it is run
+ */
+int test_mask_utils_run_dspal_test(char** test_mask, int (*test_to_run)(void), char test_name[]);
 
-int main(int argc, char *argv[])
-{
-	int status = TEST_PASS;
-
-	LOG_INFO("");
-
-	char test_mask[255];
-	if (test_mask_utils_process_cli_args(argc, argv, test_mask) != 0)
-	{
-		return 0;
-	}
-
-	LOG_INFO("Starting DSPAL tests");
-
-	dspal_tester_test_dspal_get_version_info();
-	status = run_posix_test_suite(test_mask);
-	status |= run_io_test_suite(test_mask + NUM_DSPAL_POSIX_TESTS);
-
-	if ((status & TEST_FAIL) == TEST_FAIL) {
-		LOG_INFO("DSPAL test failed.");
-
-	} else {
-		if ((status & TEST_SKIP) == TEST_SKIP) {
-			LOG_INFO("DSPAL some tests skipped.");
-		}
-
-		LOG_INFO("DSPAL tests succeeded.");
-	}
-
-	LOG_INFO("");
-	return status;
-}
-
+#endif /* TEST_MASK_UTILS_H_ */

--- a/test/dspal_tester/dspal_tester.idl
+++ b/test/dspal_tester/dspal_tester.idl
@@ -85,10 +85,17 @@ interface dspal_tester
    long serial_test();
 
    long i2c_test();
+   
+   long pwm_test();
+
+   long test_farf_log_info();
+   long test_farf_log_err();
+   long test_farf_log_debug();
 
    long test_gpio_open_close();
    long test_gpio_ioctl_io();
    long test_gpio_read_write();
+
    long test_gpio_int();
 
    long test_cxx_heap();


### PR DESCRIPTION
Adds support for PWM signals generated in software.  The updated DSP image is available here: https://www.intrinsyc.com/flight/FlightControllerHexagonSDKAddOn_2016_08_11.zip. DSPAL v1.1 is downward compatible with DSP images for DSPAL v1.0.

More information on the PWM feature is available here:
http://discuss.px4.io/t/snapdragon-flight-controller-addon-with-pwm-support/1053
