### PR TITLE
Use double quotes for non-system libraries.

### DIFF
--- a/include/dspal_time.h
+++ b/include/dspal_time.h
@@ -57,7 +57,7 @@ typedef int timer_t;
 #endif
 
 /* have to move #include here to solve circular include problems between time.h and signal.h */
-#include <dspal_signal.h>
+#include "dspal_signal.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
The reason that this commit has a rather long commit message is because the rationale is going to be important for subsequent commits ;).

This particular commit is correct for obvious reasons: the header file dspal_signal.h that is included by dspal_time.h must be of the same release/version: we really really want to include the header from the same directory as the current file.
